### PR TITLE
Fixing issue in the argument parsing when using npm i -g

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -4,7 +4,7 @@
 require('../').attachTo(console)
 
 var argv = process.argv;
-var images = process.argv.slice((argv[0] === "show-png")? 1: 2);
+var images = process.argv.slice((argv[0] === "console-png")? 1: 2);
 images = images.filter(function(filename){
   return filename.substring(filename.length - 4) === ".png"
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console-png",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Print PNG images to terminal output",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Sorry that I miswrite something before. Please see the updated version.